### PR TITLE
fix a bug on split_data

### DIFF
--- a/atlas.py
+++ b/atlas.py
@@ -53,7 +53,7 @@ def split_half_data(data, keys, dl=None):
         dl = np.ones(n_sample)
 
     fold = 2
-    skf = StratifiedKFold(dl, n_folds=fold)
+    skf = StratifiedKFold(dl, n_folds=fold, shuffle = True)
     index = []
     for train, test in skf:
         index.append(train)
@@ -64,10 +64,13 @@ def split_half_data(data, keys, dl=None):
     for f in np.arange(fold):
         f_data = data.copy()
         for k in keys:
-            f_data[k] = f_data[k][index[f],:]
-
+			if len(f_data[k].shape) == 1:
+				f_data[k] = f_data[k][index[f]]
+			elif len(f_data[k].shape) == 2:
+				f_data[k] = f_data[k][index[f],:]
+            else:
+				raise Exception('data may contains multi-dimensional data')
         sph_data.append(f_data)
-
     return sph_data
 
 


### PR DESCRIPTION
The bugs is about two parts.
1 Add a new parameter (shuffle) in function StratifiedKFold. Because it seems won't split data randomly
2 I find it's impossible to load session id and correspond gender information after split data.But if I add session id and gender into list in atlas_test.py, it will report wrong. So I add a judgment in split_half_data, if k in keys are just one dimension, it can execute rightly. And what's more, it's possible to point every data run in split_half_data as numpy.array.