### PR TITLE
Improvement of calc_overlap

### DIFF
--- a/algorithm/surf_tools.py
+++ b/algorithm/surf_tools.py
@@ -95,49 +95,6 @@ class GenAdjacentMatrix(object):
                 adjmatrix[i,j] = 1
         return adjmatrix
 
-def caloverlap(imgdata1, imgdata2, label1, label2, index = 'dice', controlsize = False, actdata = None):
-    """
-    Compute overlap (dice coefficient or percentage) in surface format data
-    
-    Parameters:
-    ----------
-    imgdata1, imgdata2: two image data in surface format
-    label1, label2: label in correspond imgdata that used for overlap
-    index: output index, dice or percent
-    controlsize: whether control roi size of label in imgdata2 to roi size of label in imgdata1 or not, the method is to extract region with highest activation and paired them with region size of imgdata1
-    actdata: by default is None, if controlsize is True, it's better to give actdata in this function
-
-    Return:
-    ----------
-    overlapidx: overlap values
-    
-    Example: 
-    ---------
-    >>> overlapidx = caloverlap(imgdata1, imgdata2, label1, label2)
-    """
-    if imgdata1.ndim == 3:
-        imgdata1 = imgdata1[:,0,0]
-    if imgdata2.ndim == 3:
-        imgdata2 = imgdata2[:,0,0]
-    if controlsize is True:
-        imgsize1 = imgdata1[imgdata1==label1].shape[0]
-        try:
-            imgdata2 = tools.control_lbl_size(imgdata2, actdata, imgsize1)   
-        except AttributeError:
-            raise Exception('We haven''t make it clear whether allow actdata as None when size need to be controlled, please input actdata here')
-    overlap = np.logical_and(imgdata1==label1, imgdata2==label2)
-    try:
-        if index == 'dice':
-            overlapidx = 2.0*len(overlap[overlap==1])/(len(imgdata1[imgdata1==label1])+len(imgdata2[imgdata2==label2]))
-        elif index == 'percent':
-            overlapidx = 1.0*len(overlap[overlap==1])/(len(imgdata1[imgdata1==label1]))
-        else:
-            raise Exception('please input dice or percent as parameters')
-    except ZeroDivisionError as e:
-        overlapidx = np.nan
-    return overlapidx
-
-
 def get_masksize(mask, labelnum = None):
     """
     Compute mask size in surface space

--- a/algorithm/tools.py
+++ b/algorithm/tools.py
@@ -743,7 +743,7 @@ def threshold_by_value(imgdata, thr, threshold_type = 'value', option = 'descend
         raise Exception('No such parameter in option')
     return imgdata_thr
 
-def control_lbl_size(labeldata, actdata, thr,label = None,  option = 'num'):
+def control_lbl_size(labeldata, actdata, thr, label = None,  option = 'num'):
     """
     Threshold label data using activation mask (threshold activation data then binarized it to get mask to restrained raw label data range)
     
@@ -763,7 +763,7 @@ def control_lbl_size(labeldata, actdata, thr,label = None,  option = 'num'):
 
     Example:
     --------
-    >>> out_lbldata = control_lbl_size(labeldata, actdata, 125, 'num')
+    >>> out_lbldata = control_lbl_size(labeldata, actdata, 125, label = 1, 'num')
     """
     # threshold activation data
     actdata = actdata*(labeldata == label)

--- a/algorithm/tools.py
+++ b/algorithm/tools.py
@@ -26,15 +26,17 @@ def _overlap(c1, c2, index='dice'):
     set1 = set(c1)
     set2 = set(c2)
     intersection_num = float(len(set1 & set2))
-    if index == 'dice':
-        total_num = len(set1 | set2) + intersection_num
-        overlap = 2 * intersection_num / total_num
-    elif index == 'percent':
-        overlap = intersection_num / len(set1)
-    else:
-        raise Exception("Only support 'dice' and 'percent' as overlap indices at present.")
+    try:
+        if index == 'dice':
+            total_num = len(set1 | set2) + intersection_num
+            overlap = 2.0 * intersection_num / total_num
+        elif index == 'percent':
+            overlap = 1.0 * intersection_num / len(set1)
+        else:
+            raise Exception("Only support 'dice' and 'percent' as overlap indices at present.")
+    except ZeroDivisionError as e:
+        overlap = np.nan
     return overlap
-
 
 def calc_overlap(data1, data2, label1=None, label2=None, index='dice', controlsize = False, actdata = None):
     """

--- a/algorithm/tools.py
+++ b/algorithm/tools.py
@@ -36,7 +36,7 @@ def _overlap(c1, c2, index='dice'):
     return overlap
 
 
-def calc_overlap(data1, data2, label1=None, label2=None, index='dice'):
+def calc_overlap(data1, data2, label1=None, label2=None, index='dice', controlsize = False, actdata = None):
     """
     Calculate overlap between two sets.
     The sets are acquired from data1 and data2 respectively.
@@ -46,31 +46,45 @@ def calc_overlap(data1, data2, label1=None, label2=None, index='dice'):
     data1, data2 : collection or numpy array
         label1 is corresponding with data1
         label2 is corresponding with data2
+    
     label1, label2 : None or labels
         If label1 or label2 is None, the corresponding data is supposed to be
         a collection of members such as vertices and voxels.
         If label1 or label2 is a label, the corresponding data is always a numpy array with same shape and meaning.
         And we will acquire set1 elements whose labels are equal to label1 from data1
         and set2 elements whose labels are equal to label2 from data2.
+    
     index : string ('dice' | 'percent')
         This parameter is used to specify index which is used to measure overlap.
+    controlsize: True or False
+        Whether control roi size or not when computing overlap index
+        If controlsize is True, please give global image data, but not a collection
+        Besides, actdata should be given.
+    
+    actdata: None or global image data
+        If controlsize is True, please input actdata that correspond to data2
 
     Return
     ------
     overlap : float
-        The overlap of set1 and set2
+        The overlap of data1 and data2
     """
-    # Transform data to collections
-    if label1 is not None and label2 is None:
+    if controlsize is True:
+        if label1 is not None and label2 is not None:
+            datasize1 = data1[data1==label1].shape[0]
+            try:
+                data2 = control_lbl_size(data2, actdata, datasize1, label = label2)
+            except AttributeError:
+                raise Exception('Please give actdata here!')
+        else:
+            raise Exception('Not support to control size of collection data')
+
+    if label1 is not None:
         positions1 = np.where(data1 == label1)
-        data1 = zip(*positions1)
-    elif label1 is None and label2 is not None:
+        data1 = zip(*positions1)    
+
+    if label2 is not None:
         positions2 = np.where(data2 == label2)
-        data2 = zip(*positions2)
-    elif label1 is not None and label2 is not None:
-        positions1 = np.where(data1 == label1)
-        positions2 = np.where(data2 == label2)
-        data1 = zip(*positions1)
         data2 = zip(*positions2)
 
     # calculate overlap
@@ -729,7 +743,7 @@ def threshold_by_value(imgdata, thr, threshold_type = 'value', option = 'descend
         raise Exception('No such parameter in option')
     return imgdata_thr
 
-def control_lbl_size(labeldata, actdata, thr, option = 'num'):
+def control_lbl_size(labeldata, actdata, thr,label = None,  option = 'num'):
     """
     Threshold label data using activation mask (threshold activation data then binarized it to get mask to restrained raw label data range)
     
@@ -752,6 +766,8 @@ def control_lbl_size(labeldata, actdata, thr, option = 'num'):
     >>> out_lbldata = control_lbl_size(labeldata, actdata, 125, 'num')
     """
     # threshold activation data
+    actdata = actdata*(labeldata == label)
+
     if option == 'num':
         outactdata = threshold_by_number(actdata, thr, 'number')
     elif option == 'value':

--- a/algorithm/tools.py
+++ b/algorithm/tools.py
@@ -70,6 +70,10 @@ def calc_overlap(data1, data2, label1=None, label2=None, index='dice', controlsi
     ------
     overlap : float
         The overlap of data1 and data2
+
+    Example:
+    --------
+    >>> overlap = calc_overlap(data1, data2, label1, label2, index = 'dice', controlsize = True, actdata = actdata)
     """
     if controlsize is True:
         if label1 is not None and label2 is not None:

--- a/graph/ncut_lib.py
+++ b/graph/ncut_lib.py
@@ -1,0 +1,147 @@
+#! /usr/bin/env python
+# coding=utf-8
+
+import numpy as np
+from scipy import sparse, rand, linalg
+from scipy.sparse.linalg import eigsh
+
+def generate_weight_matrix(N):
+    """
+    A function to randomized generate randomized weight matrix
+
+    W: nonnegative and symmetric matrix, N*N
+    """
+    m = np.random.rand(N,N)
+    m = np.triu(m)
+    m += m.T - 2*np.diag(m.diagonal())
+    return m    
+
+
+class SVDError(Exception):
+    def __init__(self, value):
+        self.value = value
+    def __str__(self):
+        return repr(self.value)
+
+def ncut(w, neig_values):
+    """
+    Normalized cut spectral clustering
+    w is simiarity matrix
+    The number of eigenvectors corresponds to the maximum number of classes
+
+    Parameters:
+    ----------
+    w: symmetric similarity matrix
+    neig_values: number of eigenvector that should be calculated
+
+    Return:
+    -------
+    eigen_val: eigenvalues from the eigen decomposition of the LaPlacian of W 
+    eigen_vec: eigenvectors from the eign decomposition of the LaPlacian of W
+    """
+    offset = 0.5
+    maxiters = 100
+    eigsErrorTolerence = 1e-6
+    eps = 2.2204e-16
+
+    m = w.shape[1]
+
+    d = np.abs(w).sum(0)
+    dr = 0.5*(d-w.sum(0))
+    d = d+offset*2
+    dr = dr+offset
+
+    # the normalized laplacian
+    w = w+sparse.spdiags(dr, [0], m, m, "csc")
+    d_invsqrt = sparse.spdiags((1.0/np.sqrt(d+eps)), [0], m, m, "csc")
+    p = d_invsqrt*(w*d_invsqrt)
+
+    # the eigen decomposition
+    eigen_val, eigen_vec = eigsh(p, neig_values, maxiter = maxiters, tol = 1e-6, which='LA')
+    
+    i = np.argsort(-eigen_val)
+    eigen_val = eigen_val[i]
+    eigen_vec = eigen_vec[:,i]
+
+    # normalize the returned eigenvectors
+    eigen_vec = d_invsqrt*np.matrix(eigen_vec)
+    norm_ones = linalg.norm(np.ones((m,1)))
+
+    for i in range(0, eigen_vec.shape[1]):
+        eigen_vec[:,i] = (eigen_vec[:,i]/linalg.norm(eigen_vec[:,i]))*norm_ones
+        if eigen_vec[0,i] != 0:
+            eigen_vec[:,i] = -1*eigen_vec[:,i]*np.sign(eigen_vec[0,i])
+    
+    return eigen_val, eigen_vec
+
+def discretisation(eigen_vec):
+    """
+    Perform the second step of normalized cut clustering which assigns feature to clusters based on the eigen vectors from the LaPlacian of a similarity matrix.
+    
+    Parameters:
+    ---------
+    eigen_vec: Eigenvectors of the normalized LaPlacian calculated from the similarity matrix for the corresponding clustering problem
+    
+    Return:
+    ---------
+    eigen_vec_discrete: discretised eigenvectors
+                        vectors of 0 and 1 which indicate whether or not a feature belongs to the cluster defined by the eigen vector
+                        i.e. a one in the 10th row of the 4th eigenvector(column) means that feature 10 belongs to cluster #4
+    """
+    eps = 2.2204e-16
+    n, k = eigen_vec.shape
+    vm = np.kron(np.ones((1,k)), np.sqrt(np.multiply(eigen_vec, eigen_vec).sum(1)))
+    eigen_vec = eigen_vec/vm
+    
+    svd_restarts = 0
+    exitLoop = 0
+
+    while (svd_restarts < 30) and (exitLoop == 0):
+        c = np.zeros((n,1))
+        R = np.matrix(np.zeros((k,k)))
+        R[:,0] = eigen_vec[int(rand(1)*(n-1)),:].transpose()
+    
+        for j in range(1,k):
+            c = c + np.abs(eigen_vec*R[:,j-1])
+            R[:,j] = eigen_vec[c.argmin(),:].transpose()
+    
+        last_objvalue = 0
+        n_iter_discrete = 0
+        n_iter_discrete_max = 20
+
+        while exitLoop == 0:
+            print('iteration {}'.format(n_iter_discrete))
+            n_iter_discrete += 1
+            t_discrete = eigen_vec*R
+        
+            j = np.reshape(np.asarray(t_discrete.argmax(1)), n)
+            eigenvec_discrete = sparse.csc_matrix((np.ones(len(j)),(range(0,n),\
+            np.array(j))), shape=(n,k))
+            tSVD = eigenvec_discrete.transpose()*eigen_vec
+            try:
+                U, S, Vh = linalg.svd(tSVD)            
+            except LinAlgError:
+                print('SVD didn''t converged, randomizing and trying again')
+                break
+        # test for convergence
+        NcutValue = 2*(n-S.sum())
+        if((np.abs(NcutValue - lastObjectValue)<eps) or (nbIterationsDiscretisation > nbIteraionsDiscretisationMax)):
+            exitLoop = 1
+        else:
+            lastObjectiveValue = NcutValue
+            R = np.matrix(Vh).transpose()*np.matrix(U).transpose()
+    
+    if exitLoop == 0:
+        raise SVDError("SVD didn't converge after 30 retries")
+    else:
+        return eigenvec_discrete
+
+
+
+
+
+
+
+
+
+

--- a/graph/ncut_lib.py
+++ b/graph/ncut_lib.py
@@ -123,13 +123,14 @@ def discretisation(eigen_vec):
             except LinAlgError:
                 print('SVD didn''t converged, randomizing and trying again')
                 break
-        # test for convergence
-        NcutValue = 2*(n-S.sum())
-        if((np.abs(NcutValue - lastObjectValue)<eps) or (nbIterationsDiscretisation > nbIteraionsDiscretisationMax)):
-            exitLoop = 1
-        else:
-            lastObjectiveValue = NcutValue
-            R = np.matrix(Vh).T*np.matrix(U).T
+
+            # test for convergence
+            NcutValue = 2*(n-S.sum())
+            if((np.abs(NcutValue - last_objvalue)<eps) or (n_iter_discrete > n_iter_discrete_max)):
+                exitLoop = 1
+            else:
+                last_objvalue = NcutValue
+                R = np.matrix(Vh).T*np.matrix(U).T
     
     if exitLoop == 0:
         raise SVDError("SVD didn't converge after 30 retries")

--- a/graph/ncut_lib.py
+++ b/graph/ncut_lib.py
@@ -137,7 +137,23 @@ def discretisation(eigen_vec):
     else:
         return eigenvec_discrete
 
-
+def gen_labelimg(eigenvec_discrete):
+    """
+    Generate label image from discretisated eigenvector
+    
+    Parameters:
+    -----------
+    eigenvec_discrete: discretisated eigenvector
+    
+    Return:
+    -------
+    labelimg: label image (surface only)
+    """
+    eigenvec_discrete = eigenvec_discrete.todense()
+    eigenvec_discrete = np.array(eigenvec_discrete)
+    labelimg = np.argmax(eigenvec_discrete, axis=1)
+    labelimg += 1
+    return labelimg 
 
 
 

--- a/graph/ncut_lib.py
+++ b/graph/ncut_lib.py
@@ -99,11 +99,11 @@ def discretisation(eigen_vec):
     while (svd_restarts < 30) and (exitLoop == 0):
         c = np.zeros((n,1))
         R = np.matrix(np.zeros((k,k)))
-        R[:,0] = eigen_vec[int(rand(1)*(n-1)),:].transpose()
+        R[:,0] = eigen_vec[int(rand(1)*(n-1)),:].T
     
         for j in range(1,k):
             c = c + np.abs(eigen_vec*R[:,j-1])
-            R[:,j] = eigen_vec[c.argmin(),:].transpose()
+            R[:,j] = eigen_vec[c.argmin(),:].T
     
         last_objvalue = 0
         n_iter_discrete = 0
@@ -117,7 +117,7 @@ def discretisation(eigen_vec):
             j = np.reshape(np.asarray(t_discrete.argmax(1)), n)
             eigenvec_discrete = sparse.csc_matrix((np.ones(len(j)),(range(0,n),\
             np.array(j))), shape=(n,k))
-            tSVD = eigenvec_discrete.transpose()*eigen_vec
+            tSVD = eigenvec_discrete.T*eigen_vec
             try:
                 U, S, Vh = linalg.svd(tSVD)            
             except LinAlgError:
@@ -129,7 +129,7 @@ def discretisation(eigen_vec):
             exitLoop = 1
         else:
             lastObjectiveValue = NcutValue
-            R = np.matrix(Vh).transpose()*np.matrix(U).transpose()
+            R = np.matrix(Vh).T*np.matrix(U).T
     
     if exitLoop == 0:
         raise SVDError("SVD didn't converge after 30 retries")


### PR DESCRIPTION
Hi, buddies, I merged calc_overlap into ATT, and have fixed several bugs.
One of the bugs is to check that when denominator be 0, the output should be np.nan.
Second is that add annotation of Example in calc_overlap
The third is to make it simple when to check the data type of data1 and data2 in calc_overlap.

Besides, I add two parameters to control ROI size when computing overlap between data1 and data2 in calc_overlap.
Also, fix a bug in control_lbl_size, make it sure to control ROI size in the same region but not around.